### PR TITLE
商品詳細表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, except: [:index]
+  before_action :authenticate_user!, except: [:index, :show]
   
   def index
     @items = Item.includes(:user).order("created_at DESC")
@@ -18,6 +18,9 @@ class ItemsController < ApplicationController
     end
   end
   
+  def show
+    @item = Item.find(params[:id])
+  end
 
   private
 

--- a/app/models/buy.rb
+++ b/app/models/buy.rb
@@ -1,0 +1,9 @@
+class Buy < ApplicationRecord
+  belongs_to :user
+  belongs_to :item
+
+  with_options presence: true do
+    validates :user
+    validates :item
+  end
+end

--- a/app/models/buy.rb
+++ b/app/models/buy.rb
@@ -1,9 +1,9 @@
-class Buy < ApplicationRecord
-  belongs_to :user
-  belongs_to :item
+# class Buy < ApplicationRecord
+  # belongs_to :user
+  # belongs_to :item
 
-  with_options presence: true do
-    validates :user
-    validates :item
-  end
-end
+  # with_options presence: true do
+    # validates :user
+    # validates :item
+  # end
+# end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -2,7 +2,7 @@ class Item < ApplicationRecord
 
   belongs_to :user
   has_one_attached :image
-  has_one :buy
+  # has_one :buy
 
   extend ActiveHash::Associations::ActiveRecordExtensions 
   belongs_to_active_hash :goods_category

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -2,6 +2,7 @@ class Item < ApplicationRecord
 
   belongs_to :user
   has_one_attached :image
+  has_one :buy
 
   extend ActiveHash::Associations::ActiveRecordExtensions 
   belongs_to_active_hash :goods_category

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -128,7 +128,7 @@
 
       <% @items.each do |item| %>
         <li class='list'>
-          <%= link_to "#" do %>
+          <%= link_to item_path(item) do %>
           <div class='item-img-content'>
             <%= image_tag item.image, class: "item-img" %>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -23,7 +23,7 @@
       </span>
     </div>
 
-    <% if current_user == @item.user %>
+    <% if current_user == @item.user && user_signed_in? %>
       <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
       <p class="or-text">or</p>
       <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -23,11 +23,11 @@
       </span>
     </div>
 
-    <% if (current_user == @item.user) && user_signed_in? %>
+    <% if user_signed_in? && (current_user == @item.user) %>
       <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
       <p class="or-text">or</p>
       <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
-    <% elsif (current_user != @item.user) && user_signed_in? && @item.buy.blank? %>
+    <% elsif user_signed_in? && (current_user != @item.user) && @item.buy.blank? %>
       <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
     <% end %>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -23,7 +23,7 @@
       </span>
     </div>
 
-    <% if current_user == @item.user && user_signed_in? %>
+    <% if (current_user == @item.user) && user_signed_in? %>
       <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
       <p class="or-text">or</p>
       <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,66 +4,61 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.title %>
     </h2>
     <div class="item-img-content">
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.image ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
-      <div class="sold-out">
-        <span>Sold Out!!</span>
-      </div>
+      <%# <div class="sold-out"> %>
+        <%# <span>Sold Out!!</span> %>
+      <%# </div> %>
       <%# //商品が売れている場合は、sold outを表示しましょう %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        <%= @item.price %>
       </span>
       <span class="item-postage">
-        <%= "配送料負担" %>
+        <%= @item.shipping_charge.name %>
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
-    <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
-    <p class="or-text">or</p>
-    <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
-
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+    <% if current_user == @item.user %>
+      <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+      <p class="or-text">or</p>
+      <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+    <% elsif (current_user != @item.user) && user_signed_in? && @item.buy.blank? %>
+      <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
+    <% end %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.text %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.goods_category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.goods_condition.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.shipping_charge.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.shipping_area.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.shipping_day.name %></td>
         </tr>
       </tbody>
     </table>
@@ -102,9 +97,9 @@
       後ろの商品 ＞
     </a>
   </div>
-  <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href="#" class="another-item"><%= "商品のカテゴリー名" %>をもっと見る</a>
-  <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
+
+  <a href="#" class="another-item"><%= @item.goods_category.name %>をもっと見る</a>
+
 </div>
 
 <%= render "shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -23,12 +23,14 @@
       </span>
     </div>
 
-    <% if user_signed_in? && (current_user == @item.user) %>
-      <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
-      <p class="or-text">or</p>
-      <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
-    <% elsif user_signed_in? && (current_user != @item.user) && @item.buy.blank? %>
-      <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
+    <% if user_signed_in? && @item.buy.blank? %>
+      <% if current_user == @item.user %>
+        <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+        <p class="or-text">or</p>
+        <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+      <% else %>
+        <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
+      <% end %>
     <% end %>
 
     <div class="item-explain-box">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,6 @@ Rails.application.routes.draw do
   devise_for :users
   root to: 'items#index'
 
-  resources :items, only: [:index, :new, :create]
+  resources :items, only: [:index, :new, :create, :show]
 
 end

--- a/db/migrate/20210428014342_create_buys.rb
+++ b/db/migrate/20210428014342_create_buys.rb
@@ -1,9 +1,9 @@
-class CreateBuys < ActiveRecord::Migration[6.0]
-  def change
-    create_table :buys do |t|
-      t.references :user,     null: false, foreign_key: true
-      t.references :item,     null: false, foreign_key: true
-      t.timestamps
-    end
-  end
-end
+# class CreateBuys < ActiveRecord::Migration[6.0]
+  # def change
+    # create_table :buys do |t|
+      # t.references :user,     null: false, foreign_key: true
+      # t.references :item,     null: false, foreign_key: true
+      # t.timestamps
+    # end
+  # end
+# end

--- a/db/migrate/20210428014342_create_buys.rb
+++ b/db/migrate/20210428014342_create_buys.rb
@@ -1,0 +1,9 @@
+class CreateBuys < ActiveRecord::Migration[6.0]
+  def change
+    create_table :buys do |t|
+      t.references :user,     null: false, foreign_key: true
+      t.references :item,     null: false, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_15_062208) do
+ActiveRecord::Schema.define(version: 2021_04_28_014342) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -31,6 +31,15 @@ ActiveRecord::Schema.define(version: 2021_04_15_062208) do
     t.string "checksum", null: false
     t.datetime "created_at", null: false
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "buys", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "item_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["item_id"], name: "index_buys_on_item_id"
+    t.index ["user_id"], name: "index_buys_on_user_id"
   end
 
   create_table "items", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -67,5 +76,7 @@ ActiveRecord::Schema.define(version: 2021_04_15_062208) do
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "buys", "items"
+  add_foreign_key "buys", "users"
   add_foreign_key "items", "users"
 end

--- a/spec/factories/buys.rb
+++ b/spec/factories/buys.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :buy do
+    
+  end
+end

--- a/spec/models/buy_spec.rb
+++ b/spec/models/buy_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Buy, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
# What
商品詳細表示機能の実装

# Why
商品の詳細内容を表示し、ログイン状態・ログアウト状態・購入済みか否かで表示ボタンを変えるため

# 機能の様子
ログイン状態の出品者のみ「編集・削除ボタン」が表示され、商品出品時に登録した情報が見られる
[https://i.gyazo.com/132e1c5f2461cc35946f00d5b0f3f1c0.gif](url)
ログイン状態の出品者以外のユーザーのみ「購入画面に進むボタン」が表示される
[https://i.gyazo.com/6203908ad25d704d7ce486c4d8e28385.gif](url)
ログアウト状態のユーザーでも商品詳細表示ページが閲覧できるが「編集・削除・購入画面に進むボタン」は表示されない
[https://i.gyazo.com/c053ef06a382f6c5b22954a0c54f43d9.gif](url)

売却済みの商品に対しては「編集・削除ボタン」が表示されないこと、に関してはコードは記述していますが、商品購入機能の実装がまだなので機能の様子は無いです。
soldoutを表示するも同様です。
